### PR TITLE
Make __wakeup a private method to prevent throwing exception

### DIFF
--- a/src/LibRegistry.php
+++ b/src/LibRegistry.php
@@ -139,11 +139,9 @@ class LibRegistry {
 	 * Must use LibRegistry::getInstance() instead.
 	 *
 	 * @return void
-	 * @throws Exception every time.
+	 * @codeCoverageIgnore Nothing to test.
 	 */
-	public function __wakeup() {
-		throw new Exception(
-			sprintf('Cannot unserialize singleton class %s.', get_called_class())
-		);
+	private function __wakeup() {
+		//no-op
 	}
 }

--- a/src/LibRegistry.php
+++ b/src/LibRegistry.php
@@ -68,6 +68,7 @@ class LibRegistry {
 	 */
 	public static function set($class, $object) {
 		static::$_instances[$class] = $object;
+
 		return static::$_instances[$class];
 	}
 

--- a/src/LibRegistryTrait.php
+++ b/src/LibRegistryTrait.php
@@ -87,6 +87,7 @@ trait LibRegistryTrait {
 		$prop = basename($class);
 
 		$this->{$prop} = $this->libs()->get($name, $config);
+
 		return $this->{$prop};
 	}
 }

--- a/tests/TestCase/LibRegistryTest.php
+++ b/tests/TestCase/LibRegistryTest.php
@@ -289,11 +289,11 @@ class LibRegistryTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotUnserialize() {
-		$this->setExpectedExceptionRegExp(
-			'Exception',
-			'/Cannot unserialize singleton class .*LibRegistry.*\./'
+		$reflection = new \ReflectionClass('\LibRegistry\LibRegistry');
+		$constructor = $reflection->getmethod('__wakeup');
+		$this->assertFalse(
+			$constructor->isPublic(),
+			'Not allowed to unserialize the singleton.'
 		);
-		$myRegistry = LibRegistry::getInstance();
-		$myRegistry->__wakeup();
 	}
 }

--- a/tests/TestCase/LibRegistryTest.php
+++ b/tests/TestCase/LibRegistryTest.php
@@ -7,6 +7,7 @@ namespace LibRegistry\Test\TestCase;
 use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use LibRegistry\LibRegistry;
+use ReflectionClass;
 
 /**
  * Subclass that
@@ -261,7 +262,7 @@ class LibRegistryTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotInstantiateExternally() {
-		$reflection = new \ReflectionClass('\LibRegistry\LibRegistry');
+		$reflection = new ReflectionClass('\LibRegistry\LibRegistry');
 		$constructor = $reflection->getConstructor();
 		$this->assertFalse(
 			$constructor->isPublic(),
@@ -275,7 +276,7 @@ class LibRegistryTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotClone() {
-		$reflection = new \ReflectionClass('\LibRegistry\LibRegistry');
+		$reflection = new ReflectionClass('\LibRegistry\LibRegistry');
 		$constructor = $reflection->getmethod('__clone');
 		$this->assertFalse(
 			$constructor->isPublic(),
@@ -289,7 +290,7 @@ class LibRegistryTest extends TestCase {
 	 * @return void
 	 */
 	public function testCannotUnserialize() {
-		$reflection = new \ReflectionClass('\LibRegistry\LibRegistry');
+		$reflection = new ReflectionClass('\LibRegistry\LibRegistry');
 		$constructor = $reflection->getmethod('__wakeup');
 		$this->assertFalse(
 			$constructor->isPublic(),


### PR DESCRIPTION
The __wakeup() method should be private to prevent unserialization instead
of public with an Exception throw call inside.

http://www.phptherightway.com/pages/Design-Patterns.html#singleton

This also fixes an issue where DebugKit was unable to unserialize this
singleton class.